### PR TITLE
Make travis test rolename agnostic.

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   become: true
   become_user: root
-  roles:
-   - role: upgrade-nextcloud
-     nextcloud_db_backend: "pgsql"
-     nextcloud_db_pwd: "azerty"
+  roles: [../../]
+  vars:
+    nextcloud_db_backend: "pgsql"
+    nextcloud_db_pwd: "azerty"


### PR DESCRIPTION
This is so that the test works for users that have renamed the role.