### PR TITLE
Do not verify DB backup if not enabled

### DIFF
--- a/tasks/nc_backup.yml
+++ b/tasks/nc_backup.yml
@@ -36,6 +36,7 @@
   with_items:
     - "{{nextcloud_backup_db}}"
     - "{{nextcloud_backup_config}}"
+  when: item != "{{nextcloud_backup_db}}" or nextcloud_db_backup
 
   # backup data folder only if in a sub-directory of nextcloud_webroot
 - name: "[NC-Backup] - Backup data folder"


### PR DESCRIPTION
The Verify task fails if nextcloud_db_backup is set to false, because the .sql file does not exist. This little patch should skip this test in this case.